### PR TITLE
설문 도메인 생성

### DIFF
--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Answer.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Answer.java
@@ -1,0 +1,11 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Answer {
+
+	@Column(name = "content")
+	private String content;
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Option.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Option.java
@@ -1,0 +1,11 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Option {
+
+	@Column(name = "content")
+	private String content;
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
@@ -1,0 +1,55 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import java.util.List;
+
+import com.juwoong.reviewforme.global.entity.BaseEntity;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "questions")
+public class Question extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "question_id")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "survey_id")
+	private Survey survey;
+
+	@ElementCollection
+	@CollectionTable(name = "options", joinColumns = @JoinColumn(name = "question_id"))
+	private List<Option> options;
+
+	@ElementCollection
+	@CollectionTable(name = "answers", joinColumns = @JoinColumn(name = "question_id"))
+	private List<Answer> answers;
+
+	public void makeOptions(List<Option> options) {
+		this.options = options;
+	}
+
+	public void makeAnswers(List<Answer> answers) {
+		this.answers = answers;
+	}
+
+	public List<Option> getOptions() {
+		return this.options;
+	}
+
+	public List<Answer> getAnswers() {
+		return this.answers;
+	}
+
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
@@ -1,0 +1,53 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.juwoong.reviewforme.global.entity.BaseEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "surveys")
+public class Survey extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "survey_id")
+	private Long id;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "description")
+	private String description;
+
+	@OneToMany(mappedBy = "survey", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@Column(name = "questions")
+	private Map<Integer, Question> questions;
+
+	protected Survey() {
+	}
+
+	public Survey(String title, String description) {
+		this.title = title;
+		this.description = description;
+		this.questions = new HashMap<>();
+	}
+
+	public void makeQuestion(Integer number, Question question) {
+		questions.put(number, question);
+	}
+
+	public void deleteQuestion(Integer number) {
+		questions.remove(number);
+	}
+
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/SurveyRepository.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/SurveyRepository.java
@@ -1,0 +1,10 @@
+package com.juwoong.reviewforme.domain.survey.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.juwoong.reviewforme.domain.survey.domain.Survey;
+
+import jakarta.persistence.Id;
+
+public interface SurveyRepository extends JpaRepository<Survey, Id> {
+}


### PR DESCRIPTION
# 🚀 Pull Request Template 🚀

&nbsp;
## 📝PR 요약
- 설문 도메인을 구현했습니다.

&nbsp;
## 👀 리뷰 포커스
- 설문 객체가 생명주기를 가지는 식별 단위라고 생각해서 엔티티로 두고 연관된 질문, 질문 옵션, 질문 답변을 벨류 값으로 두고자 했습니다.
- 하지만 두가지 이유로 질문 객체를 벨류에서 엔티티로 변경했습니다.
  - 질문과 질문 옵션, 질문 답변 관계도  설문과 질문 처럼 ElementCollection관계를 가져야하는데 중첩되어 할 수 가 없습니다. 
  - 추후 다양한 질문 유형을 상속 관계로 표현하려하는데 밸류는 상속이 불가능합니다.
- 대신 질문 객체가 의미적으로 설문 객체의 벨류값이라는 것을 전달하기 위해 casecadeType, ophanRemoval 설정을 걸어 두었습니다. 
- 질문 순서를 나타내기 위해 연관관계를 Map을 통해 표현했습니다.


&nbsp;
## 📌기타 사항
