### PR TITLE
상속 구조를 통한 질문 유형 확장성 마련

### DIFF
--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/MultipleChoice.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/MultipleChoice.java
@@ -1,0 +1,7 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class MultipleChoice extends Question {
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
@@ -11,13 +11,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
+@Inheritance(strategy = InheritanceType.JOINED)
 @Table(name = "questions")
-public class Question extends BaseEntity {
+public abstract class Question extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Subjective.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Subjective.java
@@ -1,0 +1,7 @@
+package com.juwoong.reviewforme.domain.survey.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Subjective extends Question{
+}

--- a/src/main/java/com/juwoong/reviewforme/global/entity/BaseEntity.java
+++ b/src/main/java/com/juwoong/reviewforme/global/entity/BaseEntity.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
 	@CreatedDate
 	@Column(name = "created_at", updatable = false)


### PR DESCRIPTION
# 🚀 Pull Request Template 🚀

&nbsp;
## 📝PR 요약
- 엔티티 상속구조를 통한 질문 유형에 대한 확장성을 마련했습니다.

&nbsp;
## 👀 리뷰 포커스
- 실제 코드에 기능 구현을 하지 않았지만 설문 플랫폼 분석결과 질문 유형에 따라 책임이 달라질 것을 고려해서 상속구조로 변경했습니다. 
- 질문 옵션과 질문 답변과 같은 공통 기능은 추상 클래스에 두었습니다.  
<img width="983" alt="스크린샷 2023-12-18 오후 12 37 58" src="https://github.com/JuwoongKim/review-for-me/assets/62009283/161aac69-328e-4ec8-a064-b757894d32d2">
<img width="983" alt="스크린샷 2023-12-18 오후 12 38 28" src="https://github.com/JuwoongKim/review-for-me/assets/62009283/adae3253-1a41-48ee-b623-0e91e74c3c95">

&nbsp;
## 📌기타 사항
- 주관식 질문은 질문 옵션과 여러개의 정답이 필요없는 형태다. 상속으로 받아도 되나 싶긴합니다. 
- 하지만 구글폼으로 질문 저장 요청에 대한 payload를 봤을 때  배열원소가 하나일 뿐 형식이 유사합니다.  
- 복잡하게 하지 않는 것을 기준으로 하여 주관식 질문 유형도 상속에 포함시켰습니다.
