### PR TITLE
리뷰 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.projectlombok:lombok:1.18.28'
+    annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
@@ -1,0 +1,33 @@
+package com.juwoong.reviewforme.domain.survey.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.juwoong.reviewforme.domain.survey.api.dto.CreateSurveyRequest;
+import com.juwoong.reviewforme.domain.survey.api.dto.SurveyResponse;
+import com.juwoong.reviewforme.domain.survey.application.SurveyService;
+import com.juwoong.reviewforme.domain.survey.domain.Survey;
+
+@RestController
+@RequestMapping("/survey")
+public class SurveyController {
+
+	private final SurveyService surveyService;
+
+	public SurveyController(SurveyService surveyService) {
+		this.surveyService = surveyService;
+	}
+
+	@PostMapping
+	public ResponseEntity<SurveyResponse> createSurvey(@RequestBody CreateSurveyRequest surveyRequest) {
+		Survey survey = surveyRequest.toEntity();
+		Survey createdSurvey = surveyService.createSurvey(survey);
+		SurveyResponse surveyResponse = new SurveyResponse(createdSurvey);
+
+		return new ResponseEntity<>(surveyResponse, HttpStatus.CREATED);
+	}
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateSurveyRequest.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateSurveyRequest.java
@@ -1,0 +1,12 @@
+package com.juwoong.reviewforme.domain.survey.api.dto;
+
+import com.juwoong.reviewforme.domain.survey.domain.Survey;
+
+public record CreateSurveyRequest(
+	String title,
+	String description
+) {
+	public Survey toEntity() {
+		return new Survey(title, description);
+	}
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/SurveyResponse.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/SurveyResponse.java
@@ -1,0 +1,22 @@
+package com.juwoong.reviewforme.domain.survey.api.dto;
+
+import java.util.Map;
+
+import com.juwoong.reviewforme.domain.survey.domain.Question;
+import com.juwoong.reviewforme.domain.survey.domain.Survey;
+
+public record SurveyResponse(
+	Long id,
+	String title,
+	String description,
+	Map<Integer, Question> questions
+) {
+	public SurveyResponse(Survey survey) {
+		this(
+			survey.getId(),
+			survey.getTitle(),
+			survey.getTitle(),
+			survey.getQuestions()
+		);
+	}
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
@@ -1,0 +1,26 @@
+package com.juwoong.reviewforme.domain.survey.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.juwoong.reviewforme.domain.survey.domain.Survey;
+import com.juwoong.reviewforme.domain.survey.domain.repository.SurveyRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyService {
+
+	private final SurveyRepository surveyRepository;
+
+	public SurveyService(SurveyRepository surveyRepository) {
+		this.surveyRepository = surveyRepository;
+	}
+
+	@Transactional
+	public Survey createSurvey(Survey survey) {
+		Survey createdSurvey = surveyRepository.save(survey);
+
+		return createdSurvey;
+	}
+
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
@@ -13,7 +13,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
+@Getter
 @Entity
 @Table(name = "surveys")
 public class Survey extends BaseEntity {


### PR DESCRIPTION
# 🚀 Pull Request Template 🚀

&nbsp;
## 📝PR 요약
- 리뷰 설문 생성 기능 및 api를 구현했습니다.

&nbsp;
## 👀 리뷰 포커스
- 서비스 레이어까지 도메인 순수성을 지켜야하는 범위라 생각했고, 표현계층에 의존하면 안된다고 생각했습니다. 
- 따라서 서비스 계층의 입력값과 반환값을 엔티티로 설정했습니다.
- 변환에 대한 책임은 요청, 응답 DTO에 할당했습니다.

&nbsp;
## 📌기타 사항
- 없음
