### PR TITLE
설문 조회 기능 구현

### DIFF
--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
@@ -2,6 +2,8 @@ package com.juwoong.reviewforme.domain.survey.api;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,14 @@ public class SurveyController {
 		SurveyResponse surveyResponse = new SurveyResponse(createdSurvey);
 
 		return new ResponseEntity<>(surveyResponse, HttpStatus.CREATED);
+	}
+
+	@GetMapping("/{survey-id}")
+	public ResponseEntity<SurveyResponse> getSurvey(@PathVariable("survey-id") Long surveyId) {
+		Survey survey = surveyService.getSurvey(surveyId);
+		SurveyResponse surveyResponse = new SurveyResponse(survey);
+
+		return new ResponseEntity<> (surveyResponse, HttpStatus.OK);
 	}
 
 	@PostMapping("/question")

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateItemRequest.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateItemRequest.java
@@ -6,6 +6,7 @@ import com.juwoong.reviewforme.domain.survey.domain.item.Item;
 import com.juwoong.reviewforme.domain.survey.domain.Option;
 
 public record CreateItemRequest(
+	Long itemId,
 	String itemTitle,
 	Item.ItemType itemType,
 	List<CreateOptionRequest> itemOptions
@@ -13,6 +14,6 @@ public record CreateItemRequest(
 	public Item toEntity() {
 		List<Option> options = itemOptions.stream().map(request -> request.toValue()).toList();
 
-		return itemType.create(this.itemTitle, options);
+		return itemType.create(this.itemId, this.itemTitle, options);
 	}
 }

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateQuestionRequest.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/CreateQuestionRequest.java
@@ -6,6 +6,7 @@ import com.juwoong.reviewforme.domain.survey.domain.Question;
 import com.juwoong.reviewforme.domain.survey.domain.item.Item;
 
 public record CreateQuestionRequest(
+	Long questionId,
 	Integer questionOrder,
 	String questionTitle,
 	String questionDescription,
@@ -14,6 +15,6 @@ public record CreateQuestionRequest(
 	public Question toEntity() {
 		List<Item> items = questionItems.stream().map(request -> request.toEntity()).toList();
 
-		return new Question(questionTitle, questionDescription, items);
+		return new Question(questionId, questionTitle, questionDescription, items);
 	}
 }

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
@@ -5,8 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.juwoong.reviewforme.domain.survey.domain.Question;
 import com.juwoong.reviewforme.domain.survey.domain.Survey;
-import com.juwoong.reviewforme.domain.survey.domain.repository.ItemRepository;
-import com.juwoong.reviewforme.domain.survey.domain.repository.QuestionRepository;
 import com.juwoong.reviewforme.domain.survey.domain.repository.SurveyRepository;
 
 @Service
@@ -14,14 +12,9 @@ import com.juwoong.reviewforme.domain.survey.domain.repository.SurveyRepository;
 public class SurveyService {
 
 	private final SurveyRepository surveyRepository;
-	private final QuestionRepository questionRepository;
-	private final ItemRepository itemRepository;
 
-	public SurveyService(SurveyRepository surveyRepository, QuestionRepository questionRepository,
-		ItemRepository itemRepository) {
+	public SurveyService(SurveyRepository surveyRepository) {
 		this.surveyRepository = surveyRepository;
-		this.questionRepository = questionRepository;
-		this.itemRepository = itemRepository;
 	}
 
 	@Transactional
@@ -41,12 +34,10 @@ public class SurveyService {
 	public Question createQuestion(Long surveyId, Integer questionOrder, Question question) {
 		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
 		survey.makeQuestion(questionOrder, question);
-		question.setSurvey(survey);
+		Survey saveSurvey = surveyRepository.save(survey);
 
-		Question createdQuestion = questionRepository.save(question);
+		Question createdQuestion = saveSurvey.getQuestions().get(questionOrder);
 
 		return createdQuestion;
-
 	}
-
 }

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
@@ -31,14 +31,19 @@ public class SurveyService {
 		return createdSurvey;
 	}
 
+	public Survey getSurvey(Long surveyId) {
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+
+		return survey;
+	}
+
 	@Transactional
 	public Question createQuestion(Long surveyId, Integer questionOrder, Question question) {
 		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-		survey.makeQuestion(questionOrder,question);
+		survey.makeQuestion(questionOrder, question);
 		question.setSurvey(survey);
 
 		Question createdQuestion = questionRepository.save(question);
-
 
 		return createdQuestion;
 

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Question.java
@@ -12,7 +12,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -33,11 +32,7 @@ public class Question extends BaseEntity {
 	@Column(name = "description")
 	private String description;
 
-	@ManyToOne
-	@JoinColumn(name = "survey_id")
-	private Survey survey;
-
-	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true)
 	@JoinColumn(name = "question_id")
 	private List<Item> items;
 
@@ -45,13 +40,10 @@ public class Question extends BaseEntity {
 
 	}
 
-	public Question(String title, String description, List<Item> items) {
+	public Question(Long id, String title, String description, List<Item> items) {
+		this.id = id;
 		this.title = title;
 		this.description = description;
 		this.items = items;
-	}
-
-	public void setSurvey(Survey survey) {
-		this.survey = survey;
 	}
 }

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -31,7 +32,8 @@ public class Survey extends BaseEntity {
 	@Column(name = "description")
 	private String description;
 
-	@OneToMany(mappedBy = "survey", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true)
+	@JoinColumn(name = "survey_id")
 	private Map<Integer, Question> questions;
 
 	protected Survey() {

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/Item.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/Item.java
@@ -32,39 +32,39 @@ public abstract class Item {
 
 		SHORT_ANSWER() {
 			@Override
-			public Item create(String title, List<Option> options) {
-				return new ItemShortAnswer(title, options);
+			public Item create(Long id, String title, List<Option> options) {
+				return new ItemShortAnswer(id, title, options);
 			}
 		}, PARAGRAPH() {
 			@Override
-			public Item create(String title, List<Option> options) {
-				return new ItemParagraph(title, options);
+			public Item create(Long id, String title, List<Option> options) {
+				return new ItemParagraph(id, title, options);
 			}
 		}, CHECKBOX() {
 			@Override
-			public Item create(String title, List<Option> options) {
-				return new ItemCheckBox(title, options);
+			public Item create(Long id, String title, List<Option> options) {
+				return new ItemCheckBox(id, title, options);
 			}
 		}, DROPDOWN() {
 			@Override
-			public Item create(String title, List<Option> options) {
-				return new ItemDropDown(title, options);
+			public Item create(Long id, String title, List<Option> options) {
+				return new ItemDropDown(id, title, options);
 			}
 		}, MULTIPLE_CHOICE() {
 			@Override
-			public Item create(String title, List<Option> options) {
-				return new ItemMultipleChoice(title, options);
+			public Item create(Long id, String title, List<Option> options) {
+				return new ItemMultipleChoice(id, title, options);
 			}
 		};
 
-		public abstract Item create(String title, List<Option> options);
+		public abstract Item create(Long id, String title, List<Option> options);
 
 	}
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "item_id")
-	private Long id;
+	public Long id;
 
 	@Column(name = "item_title")
 	public String title;
@@ -76,5 +76,4 @@ public abstract class Item {
 	@ElementCollection
 	@CollectionTable(name = "answers", joinColumns = @JoinColumn(name = "item_id"))
 	public List<Answer> answers = new ArrayList<>();
-
 }

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemCheckBox.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemCheckBox.java
@@ -14,7 +14,8 @@ public class ItemCheckBox extends Item implements Selective {
 	protected ItemCheckBox() {
 	}
 
-	public ItemCheckBox(String title, List<Option> options) {
+	public ItemCheckBox(Long id, String title, List<Option> options) {
+		this.id = id;
 		this.title = title;
 		this.options = options;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemDropDown.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemDropDown.java
@@ -14,7 +14,8 @@ public class ItemDropDown extends Item implements Selective {
 	protected ItemDropDown() {
 	}
 
-	public ItemDropDown(String title, List<Option> options) {
+	public ItemDropDown(Long id, String title, List<Option> options) {
+		this.id = id;
 		this.title = title;
 		this.options = options;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemMultipleChoice.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemMultipleChoice.java
@@ -14,7 +14,8 @@ public class ItemMultipleChoice extends Item implements Selective {
 	protected ItemMultipleChoice() {
 	}
 
-	public ItemMultipleChoice(String title, List<Option> options) {
+	public ItemMultipleChoice(Long id, String title, List<Option> options) {
+		this.id = id;
 		this.title = title;
 		this.options = options;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemParagraph.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemParagraph.java
@@ -14,7 +14,8 @@ public class ItemParagraph extends Item implements Subjective {
 	protected ItemParagraph() {
 	}
 
-	public ItemParagraph(String title, List<Option> options) {
+	public ItemParagraph(Long id, String title, List<Option> options) {
+		this.id = id;
 		this.title = title;
 		this.options = options;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemShortAnswer.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/item/ItemShortAnswer.java
@@ -14,7 +14,8 @@ public class ItemShortAnswer extends Item implements Subjective {
 	protected ItemShortAnswer() {
 	}
 
-	public ItemShortAnswer(String title, List<Option> options) {
+	public ItemShortAnswer(Long id, String title, List<Option> options) {
+		this.id = id;
 		this.title = title;
 		this.options = options;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/ItemRepository.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/ItemRepository.java
@@ -1,8 +1,0 @@
-package com.juwoong.reviewforme.domain.survey.domain.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.juwoong.reviewforme.domain.survey.domain.item.Item;
-
-public interface ItemRepository extends JpaRepository<Item, Long> {
-}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/QuestionRepository.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/repository/QuestionRepository.java
@@ -1,8 +1,0 @@
-package com.juwoong.reviewforme.domain.survey.domain.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.juwoong.reviewforme.domain.survey.domain.Question;
-
-public interface QuestionRepository extends JpaRepository<Question, Long> {
-}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    open-in-view: false
+    open-in-view: true
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    open-in-view: false
+    open-in-view: true
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,10 +9,19 @@ spring:
     open-in-view: true
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
       generate-ddl: true
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        type:
+          descriptor:
+            sql: trace


### PR DESCRIPTION
# 🚀 Pull Request Template 🚀

&nbsp;
## 📝PR 요약
- 설문 단일 조회기능을 구현했습니다. 전체 조회는 유저 도메인을 생성한 후에 사용자별 전체조회로 구현할 예정입니다.
- 본의 아니게 해당 pr을 통해서 질문, 아이템 엔티티를 설문 엔티티의 도메인 로직에 종속되도록 변경했습니다.

&nbsp;
## 👀 리뷰 포커스
- 서비스 계층에서 엔티티 반환, 프레젠테이션 계층에서 요청 응답 변환 책임을 유지하기 위해 OSIV 설정을 기본값인 true로 되돌렸습니다.
- 기존 도메인의 루트 엔티티는 설문이였는데, @ElementCollection 중첩 기능 지원 불가 문제로 질문과 질문 아이템을 엔티티로 사용해야했습니다. 
   해당 엔티티를 설문 도메인 로직으로만 변경되도록, 질문, 아이템 엔티티의 cascade 설정을 변경하고 레포지토리를 삭제했습니다.  
   즉 질문, 아이템 레포지토리 없이 설문 도메인 로직과 레포지토리로  모든 작업을 수행할 수 있습니다.

&nbsp;
## 📌기타 사항
