### PR TITLE
작성자별 설문 답변 조회

### DIFF
--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/SurveyController.java
@@ -1,5 +1,7 @@
 package com.juwoong.reviewforme.domain.survey.api;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,7 @@ import com.juwoong.reviewforme.domain.survey.api.dto.CreateSurveyRequest;
 import com.juwoong.reviewforme.domain.survey.api.dto.CreateSurveyResultRequest;
 import com.juwoong.reviewforme.domain.survey.api.dto.QuestionResponse;
 import com.juwoong.reviewforme.domain.survey.api.dto.SurveyResponse;
+import com.juwoong.reviewforme.domain.survey.api.dto.SurveyResultPageResponse;
 import com.juwoong.reviewforme.domain.survey.api.dto.SurveyResultResponse;
 import com.juwoong.reviewforme.domain.survey.application.SurveyService;
 import com.juwoong.reviewforme.domain.survey.domain.Answer;
@@ -78,6 +81,28 @@ public class SurveyController {
 		SurveyResultResponse surveyResultResponse = new SurveyResultResponse(createdSurveyResult);
 
 		return new ResponseEntity<>(surveyResultResponse, HttpStatus.CREATED);
+	}
+
+	@GetMapping("/surveyResult")
+	public ResponseEntity<SurveyResultPageResponse> getSurveyResults(
+		@RequestParam("survey-id") Long surveyId,
+		@RequestParam(defaultValue = "0") Integer index,
+		@RequestParam(defaultValue = "12") Integer size
+	) {
+		List<SurveyResult> surveyResults = surveyService.getSurveyResults(surveyId, index, size);
+		boolean hasNext = surveyResults.size() == size;
+
+		List<SurveyResultResponse> SurveyResultResponses = surveyResults.stream()
+			.map(surveyResult -> new SurveyResultResponse(surveyResult))
+			.toList();
+
+		SurveyResultPageResponse surveyResultPageResponse = new SurveyResultPageResponse(
+			SurveyResultResponses,
+			index + size - 1,
+			hasNext
+		);
+
+		return new ResponseEntity<>(surveyResultPageResponse, HttpStatus.OK);
 	}
 
 	@PostMapping("/surveyResult/answer")

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/SurveyResultPageResponse.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/api/dto/SurveyResultPageResponse.java
@@ -1,0 +1,10 @@
+package com.juwoong.reviewforme.domain.survey.api.dto;
+
+import java.util.List;
+
+public record SurveyResultPageResponse(
+	List<SurveyResultResponse> surveyResponses,
+	Integer index,
+	boolean hasNext
+) {
+}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/application/SurveyService.java
@@ -1,5 +1,7 @@
 package com.juwoong.reviewforme.domain.survey.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,14 +56,21 @@ public class SurveyService {
 		return lastSurveyResult;
 	}
 
+	public List<SurveyResult> getSurveyResults(Long surveyId, Integer index, Integer size) {
+		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
+		List<SurveyResult> surveyResults = survey.getSurveyResults(index, size);
+
+		return surveyResults;
+	}
+
 	@Transactional
 	public SurveyResult receiveAnswer(Long surveyId, Long surveyResultId, Answer answer) {
 		Survey survey = surveyRepository.findById(surveyId).orElseThrow(() -> new RuntimeException());
-		SurveyResult surveyResult = survey.findSurveyResult(surveyResultId);
+		SurveyResult surveyResult = survey.getSurveyResult(surveyResultId);
 		surveyResult.addAnwer(answer);
 
 		Survey savedSurvey = surveyRepository.save(survey);
-		SurveyResult savedSurveyResult = savedSurvey.findSurveyResult(surveyResultId);
+		SurveyResult savedSurveyResult = savedSurvey.getSurveyResult(surveyResultId);
 
 		return savedSurveyResult;
 	}

--- a/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
+++ b/src/main/java/com/juwoong/reviewforme/domain/survey/domain/Survey.java
@@ -67,12 +67,24 @@ public class Survey extends BaseEntity {
 		return surveyResults.get(lastIndex);
 	}
 
-	public SurveyResult findSurveyResult(Long surveyResultId) {
+	public SurveyResult getSurveyResult(Long surveyResultId) {
 		SurveyResult selectedSurveyResult = surveyResults.stream()
 			.filter(surveyResult -> surveyResult.getId() == surveyResultId)
 			.findFirst()
 			.orElseThrow(() -> new EntityNotFoundException());
 
 		return selectedSurveyResult;
+	}
+
+	public List<SurveyResult> getSurveyResults(Integer index, Integer size) {
+		Integer endIndex = (index + size <= surveyResults.size()) ? index + size : surveyResults.size();
+
+		if (index == endIndex) {
+			return new ArrayList<>();
+		}
+
+		List<SurveyResult> subSurveyResults = surveyResults.subList(index, endIndex);
+
+		return subSurveyResults;
 	}
 }


### PR DESCRIPTION
# 🚀 Pull Request Template 🚀

&nbsp;
## 📝PR 요약
- 작성자별 설문 답변 조회를 다양하게 사용하기 위해 size를 만들어 필요에 맞게 사용하도록 했습니다.

&nbsp;
## 👀 리뷰 포커스
- 단순히 단일  조회, 전체 조회, 전체 페이징 조회를 구현하는 것은 의미없다고 생각했습니다.
- 설문 결과 응답은 전체조회와 단일 조회를 구별하는 것이 아직까지는 불필요 했습니다.
- 구성하는 회면 중 10개씩, 1개씩 조회할 가능성이 있습니다. 해당 api를 공통으로 사용할 수 있다고 생각합니다.

&nbsp;
## 📌기타 사항
- 과연 전체조회와 단일 조회의 응답 객체가 분리되어야할까 라는 의문이 들었습니다.
- 아래 자료를 참고했습니다.
- https://www.inflearn.com/questions/244464/select-%EC%A1%B0%ED%9A%8C-%EC%84%B1%EB%8A%A5-%EA%B4%80%EB%A0%A8-%EC%A7%88%EB%AC%B8?re_comment_id=119988